### PR TITLE
feature:changed CS50 library for SQL into sqlite3 library

### DIFF
--- a/databaseTest.py
+++ b/databaseTest.py
@@ -1,11 +1,13 @@
-from cs50 import SQL
+import sqlite3
 import csv
 
-db = SQL("sqlite:///database.db")
+con = sqlite3.connect("database.db")
+db = con.cursor()
 
 users = db.execute("SELECT * FROM USERS")
+users = db.fetchall()
 existingUsers = db.execute("SELECT id,username FROM USERS")
-existingUsers = list({(user['id'],user['username']) for user in existingUsers})    # turn existing users into a list
+existingUsers = list({(user[0],user[1]) for user in existingUsers})    # turn existing users into a list
 
 
 # Hard coded KEYS just in case
@@ -21,13 +23,11 @@ def databaseToCsv():
     writer.writerow(KEYS) 
     
     # Write data rows
+    print(f"{existingUsers}")
     for user in users:
-      writer.writerow(user.values())
+      writer.writerow(user)
   file.close()
 
-# writeToCsv()
-# file = open("databaseToCsv.txt","r")
-# print(file.read())
 
 def csvToDatabase():
   with open("databaseToCsv.txt", newline="") as file:
@@ -68,4 +68,4 @@ def csvToDatabase():
         print(f"User {user_id}, {username} already Exists.")
   file.close()
 
-csvToDatabase()
+databaseToCsv()

--- a/databaseTest.py
+++ b/databaseTest.py
@@ -1,11 +1,11 @@
 import sqlite3
 import csv
 
-con = sqlite3.connect("database.db")
-db = con.cursor()
+con = sqlite3.connect("database.db")      # connects to the database
+db = con.cursor()                         # cursor to go through database (allows db.execute() basically)
 
 users = db.execute("SELECT * FROM USERS")
-users = db.fetchall()
+users = db.fetchall()          # get all the users cuz this library doesnt do it for you
 existingUsers = db.execute("SELECT id,username FROM USERS")
 existingUsers = list({(user[0],user[1]) for user in existingUsers})    # turn existing users into a list
 

--- a/databaseToCsv.txt
+++ b/databaseToCsv.txt
@@ -1,5 +1,5 @@
 id,username,password,position
 1,Jax,000,STUDENT
-2,Calvin,000
-3,Eric,,STUDENT
+2,Calvin,000,STUDENT
+3,Eric,000,STUDENT
 4,Jelwin,000,LECTURER


### PR DESCRIPTION
since willie said that using the CS50 library doesnt make sense on a commercial scale, i looked up what substitutes people use for the CS50 library for the SQL command and i found that people recommended this library , since we're using sqlite3 anyways. Suprisingly you dont have to pip install this library and it just plugs and plays.

Notes: the cs50 library imports stuff as dictionaries, this library imports stuff as tuples so i cant use keys to access values anymore